### PR TITLE
Skip generating a diff image if there are no differences

### DIFF
--- a/src/matchers.test.ts
+++ b/src/matchers.test.ts
@@ -47,10 +47,10 @@ describe('matchers.ts', () => {
       const result = toMatchBaseline(latestPath);
 
       expect(result.message()).toBe(
-        'Compared screenshot to match baseline. 0 were different.'
+        'Compared screenshot to match baseline. No differences were found.'
       );
       expect(result.pass).toBe(true);
-      expect(writeFileMock).toHaveBeenCalledTimes(1);
+      expect(writeFileMock).toHaveBeenCalledTimes(0);
     });
 
     it('should compare two different images', () => {

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -50,6 +50,14 @@ export const toMatchBaseline = (latestPath: string) => {
     colorThreshold: 0.1,
   });
 
+  if (pixels === 0) {
+    return {
+      message: () =>
+        `Compared screenshot to match baseline. No differences were found.`,
+      pass: true,
+    };
+  }
+
   fs.mkdirSync(path.dirname(diffPath), { recursive: true });
 
   const diffPng = { ...diff! } as PNG;


### PR DESCRIPTION
Closes #18.

With a single test case:

**Before**
✨  Done in 12.45s.

**After**
✨  Done in 4.34s.