### PR TITLE
docs: update `/example` readme

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -40,10 +40,11 @@ yarn android
 
 ## Development
 
-To use a local version of react-native-owl, first, navigate to the local directory of react-native-owl(one level up from the current directory) and run the following command:
+To use a local version of react-native-owl, first, navigate to the local directory of react-native-owl (one level up from the current directory) and run the following commands:
 
 ```sh
 # Assuming you are inside react-native-owl - ie. ~/Projects/react-native-owl
+yarn build
 yarn watch
 ```
 


### PR DESCRIPTION
This is just a small docs change for future contributors.

I found that when messing around within the example app, and testing a failure case (i.e removing text and rebuilding/running the owl test again) will initially blow up since the `/report/index.html` template doesn't get copied to `/dist` unless the `postbuild` action runs inside the main owl directory first.

So this just adds that instruction to the example readme.