### PR TITLE
Updates to the getting started documentation to make it more explicit that the file names matter

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -34,7 +34,7 @@ Below you can find an example config (can also be found in the [example app](htt
 
 ### Add tests
 
-Use the [takeScreenshot](/docs/api/methods#takescreenshotname-string) and [.toMatchBaseline](/docs/api/matchers#tomatchbaselinename-string) api's to implement screenshot tests.
+Use the [takeScreenshot](/docs/api/methods#takescreenshotname-string) and [.toMatchBaseline](/docs/api/matchers#tomatchbaselinename-string) apis to implement screenshot tests. File names must end in `.owl.ts` or `.owl.tsx`. [See the example app](https://github.com/FormidableLabs/react-native-owl/tree/main/example) for a more complete example.
 
 #### Example
 


### PR DESCRIPTION
I fixed a typo (`api's`/ `apis`) and added some verbiage regarding file extensions. I also added a link to the example app in the getting started docs.

Changed after listening to @robwalkerco and @jamonholmgren talk about the library on react-native live.