### PR TITLE
Correct DEFAULT_BINARY_DIR to include DerivedData

### DIFF
--- a/lib/cli/run.ts
+++ b/lib/cli/run.ts
@@ -11,7 +11,7 @@ import { waitFor } from '../utils/wait-for';
 
 export const runIOS = async (config: Config, logger: Logger) => {
   const stdio = config.debug ? 'inherit' : 'ignore';
-  const DEFAULT_BINARY_DIR = `/ios/build/Build/Products/${config.ios?.configuration}-iphonesimulator`;
+  const DEFAULT_BINARY_DIR = `/ios/build/DerivedData/Build/Products/${config.ios?.configuration}-iphonesimulator`;
   const cwd = config.ios?.binaryPath
     ? path.dirname(config.ios?.binaryPath)
     : path.join(process.cwd(), DEFAULT_BINARY_DIR);


### PR DESCRIPTION
Hi everyone,
Thank you so much for this lib! 

We are setting up react-native-owl for ios and find an issue with `DEFAULT_BINARY_DIR`.

It should include `DerivedData` and we believe that it should be the same for other folks.
If that's not the case, please feel free to close this PR.
Thank you very much.

