### PR TITLE
WIP Add support for mocking files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ typings/
 
 # generated js
 dist/
+
+# IntelliJ
+/.idea

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import {
-  ActivityIndicator,
   Image,
-  Pressable,
   ScrollView,
   StatusBar,
   StyleSheet,
   Text,
-  TextInput,
   View,
 } from 'react-native';
+import { PressMe } from './src/PressMe';
 
 const Section: React.FC<{
   title: string;
@@ -23,20 +21,6 @@ const Section: React.FC<{
 };
 
 const App = () => {
-  const [text, setText] = React.useState('');
-  const [isLongPressed, setIsLongPressed] = React.useState(false);
-  const [isLoading, setIsLoading] = React.useState(false);
-  const [isLoaded, setIsLoaded] = React.useState(false);
-
-  React.useEffect(() => {
-    if (isLoading) {
-      setTimeout(() => {
-        setIsLoading(false);
-        setIsLoaded(true);
-      }, 1500);
-    }
-  }, [isLoading]);
-
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
@@ -48,39 +32,7 @@ const App = () => {
 
       <Image source={require('./assets/logo.png')} style={styles.logo} />
 
-      <View style={styles.header}>
-        {!isLoaded && !isLoading && (
-          <Pressable
-            testID="Pressable"
-            onPress={() => setIsLoading(true)}
-            onLongPress={() => setIsLongPressed(true)}
-            style={styles.button}
-          >
-            <Text style={styles.buttonText}>Press Me</Text>
-            <Text style={styles.buttonArrow}>&#8594;</Text>
-          </Pressable>
-        )}
-
-        {isLoading && <ActivityIndicator />}
-
-        {isLongPressed && !isLoading && !isLoaded && (
-          <Text style={styles.textLongPressed}>Long Pressed!</Text>
-        )}
-
-        {!isLoading && isLoaded && (
-          <>
-            <Text style={styles.textInputLabel}>This is a label *</Text>
-
-            <TextInput
-              testID="TextInput"
-              placeholder="Type something here"
-              onChangeText={setText}
-              value={text}
-              style={styles.textInput}
-            />
-          </>
-        )}
-      </View>
+      <PressMe />
 
       <Section title="Setup">
         Install <Text style={styles.highlight}>react-native-owl</Text> and
@@ -128,25 +80,6 @@ const styles = StyleSheet.create({
     width: 175,
     height: 175,
     alignSelf: 'center',
-  },
-  header: {
-    marginVertical: 35,
-  },
-  button: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    borderWidth: 2,
-    paddingVertical: 7.5,
-    paddingHorizontal: 20,
-    borderRadius: 20,
-  },
-  buttonText: {
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  buttonArrow: {
-    fontSize: 20,
   },
   sectionContainer: {
     marginBottom: 32,

--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -1,3 +1,22 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
+  plugins: [
+    [
+      'module-resolver',
+      {
+        root: ['./src'],
+        extensions: [
+          '.owl.ts',
+          '.owl.tsx',
+          '.owl.js',
+          '.owl.jsx',
+          '.ts',
+          '.tsx',
+          '.js',
+          '.jsx',
+        ],
+        alias: {},
+      },
+    ],
+  ],
 };

--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -14,6 +14,28 @@ const extraNodeModules = {
 };
 const watchFolders = [path.resolve(path.join(__dirname, '..', 'dist'))];
 
+const resolver = {
+  extraNodeModules: new Proxy(extraNodeModules, {
+    get: (target, name) =>
+      name in target
+        ? target[name]
+        : path.join(process.cwd(), `node_modules/${name}`),
+  }),
+};
+
+if (process.env.OWL_BUILD) {
+  resolver.sourceExts = [
+    'owl.ts',
+    'owl.tsx',
+    'owl.js',
+    'owl.jsx',
+    'ts',
+    'tsx',
+    'js',
+    'jsx',
+  ];
+}
+
 module.exports = {
   transformer: {
     getTransformOptions: async () => ({
@@ -23,13 +45,6 @@ module.exports = {
       },
     }),
   },
-  resolver: {
-    extraNodeModules: new Proxy(extraNodeModules, {
-      get: (target, name) =>
-        name in target
-          ? target[name]
-          : path.join(process.cwd(), `node_modules/${name}`),
-    }),
-  },
+  resolver,
   watchFolders,
 };

--- a/example/package.json
+++ b/example/package.json
@@ -27,6 +27,7 @@
     "@types/react-native": "^0.65.0",
     "@types/react-test-renderer": "^17.0.1",
     "babel-jest": "^26.6.3",
+    "babel-plugin-module-resolver": "^4.1.0",
     "eslint": "^7.14.0",
     "jest": "^26.6.3",
     "metro-react-native-babel-preset": "^0.66.2",

--- a/example/src/PressMe.button.owl.tsx
+++ b/example/src/PressMe.button.owl.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { Button } from 'react-native';
+
+export const PressMeButton = () => {
+  return <Button title={'Owl Button'} />;
+};

--- a/example/src/PressMe.button.tsx
+++ b/example/src/PressMe.button.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { Button } from 'react-native';
+
+export const PressMeButton = () => {
+  return <Button title={'App Button'} />;
+};

--- a/example/src/PressMe.tsx
+++ b/example/src/PressMe.tsx
@@ -1,0 +1,106 @@
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import React from 'react';
+import { PressMeButton } from './PressMe.button';
+
+export const PressMe = () => {
+  const [text, setText] = React.useState('');
+  const [isLongPressed, setIsLongPressed] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [isLoaded, setIsLoaded] = React.useState(false);
+
+  React.useEffect(() => {
+    if (isLoading) {
+      setTimeout(() => {
+        setIsLoading(false);
+        setIsLoaded(true);
+      }, 1500);
+    }
+  }, [isLoading]);
+
+  return (
+    <View style={styles.header}>
+      {!isLoaded && !isLoading && (
+        <Pressable
+          testID="Pressable"
+          onPress={() => setIsLoading(true)}
+          onLongPress={() => setIsLongPressed(true)}
+          style={styles.button}
+        >
+          <Text style={styles.buttonText}>Press Me</Text>
+          <Text style={styles.buttonArrow}>&#8594;</Text>
+        </Pressable>
+      )}
+
+      {isLoading && <ActivityIndicator />}
+
+      {isLongPressed && !isLoading && !isLoaded && (
+        <Text style={styles.textLongPressed}>Long Pressed!</Text>
+      )}
+
+      {!isLoading && isLoaded && (
+        <>
+          <Text style={styles.textInputLabel}>This is a label *</Text>
+
+          <TextInput
+            testID="TextInput"
+            placeholder="Type something here"
+            onChangeText={setText}
+            value={text}
+            style={styles.textInput}
+          />
+
+          <PressMeButton />
+        </>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    marginVertical: 35,
+  },
+  button: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    borderWidth: 2,
+    paddingVertical: 7.5,
+    paddingHorizontal: 20,
+    borderRadius: 20,
+  },
+  textLongPressed: {
+    marginTop: 35,
+    fontSize: 20,
+    fontStyle: 'italic',
+    textAlign: 'center',
+  },
+  textInputLabel: {
+    fontWeight: '600',
+    marginBottom: 5,
+    paddingHorizontal: 20,
+  },
+  textInput: {
+    borderWidth: 1,
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 20,
+  },
+  highlight: {
+    fontWeight: '700',
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  buttonArrow: {
+    fontSize: 20,
+  },
+});

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1781,6 +1781,17 @@ babel-plugin-jest-hoist@^26.6.2:
     "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-module-resolver@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz#22a4f32f7441727ec1fbf4967b863e1e3e9f33e2"
+  integrity sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==
+  dependencies:
+    find-babel-config "^1.2.0"
+    glob "^7.1.6"
+    pkg-up "^3.1.0"
+    reselect "^4.0.0"
+    resolve "^1.13.1"
+
 babel-plugin-polyfill-corejs2@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz#440f1b70ccfaabc6b676d196239b138f8a2cfba5"
@@ -2984,6 +2995,14 @@ finalhandler@1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
+find-babel-config@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
+  integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
+
 find-cache-dir@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -3498,6 +3517,13 @@ is-core-module@^2.2.0, is-core-module@^2.8.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
   integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
+  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
   dependencies:
     has "^1.0.3"
 
@@ -4266,6 +4292,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
+json5@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+  integrity sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==
 
 json5@^2.2.1:
   version "2.2.1"
@@ -5294,6 +5325,13 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pkg-up@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
+
 plist@^3.0.2, plist@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.5.tgz#2cbeb52d10e3cdccccf0c11a63a85d830970a987"
@@ -5652,6 +5690,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+reselect@^4.0.0:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.6.tgz#19ca2d3d0b35373a74dc1c98692cdaffb6602656"
+  integrity sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -5685,6 +5728,15 @@ resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.18.1:
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
   dependencies:
     is-core-module "^2.8.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.13.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 

--- a/lib/cli/build.ts
+++ b/lib/cli/build.ts
@@ -15,7 +15,7 @@ export const buildIOS = async (
   const buildCommand = config.ios?.buildCommand
     ? [config.ios?.buildCommand]
     : [
-        `xcodebuild`,
+        `env OWL_BUILD=1 xcodebuild`,
         `-workspace ${config.ios?.workspace}`,
         `-scheme ${config.ios?.scheme}`,
         `-configuration ${config.ios?.configuration}`,

--- a/native/android/src/main/java/com/formidable/reactnativeowl/ReactNativeOwlModule.java
+++ b/native/android/src/main/java/com/formidable/reactnativeowl/ReactNativeOwlModule.java
@@ -1,14 +1,25 @@
 package com.formidable.reactnativeowl;
 
+import android.app.Activity;
+import android.view.View;
+
 import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.module.annotations.ReactModule;
 
 @ReactModule(name = ReactNativeOwlModule.NAME)
 public class ReactNativeOwlModule extends ReactContextBaseJavaModule {
     public static final String NAME = "ReactNativeOwl";
+
+    private static final int UI_FLAG_IMMERSIVE = View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+            | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION // hide nav bar
+            | View.SYSTEM_UI_FLAG_FULLSCREEN // hide status bar
+            | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
 
     public ReactNativeOwlModule(ReactApplicationContext reactContext) {
         super(reactContext);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "watch": "tsc --watch",
     "prettier:check": "prettier --check 'lib/**/*.{js,ts,tsx}'",
     "prettier:apply": "prettier --write 'lib/**/*.{js,ts,tsx}'",
-    "test": "yarn jest"
+    "test": "yarn jest",
+    "example": "yarn --cwd example"
   },
   "repository": "https://github.com/FormidableLabs/react-native-owl.git",
   "author": "Emmanouil Konstantinidis <hello@manos.im>",


### PR DESCRIPTION
### Description

This PR sets the **OWL_BUILD** environment variable when building the app using the `owl:build:*` process. 
The variable can be used to configure the [metro.config.js](#) file to change the priority of the file extensions. For example in the example app:

```
if (process.env.OWL_BUILD) {
  resolver.sourceExts = [
    'owl.ts',
    'owl.tsx',
    'owl.js',
    'owl.jsx',
    'ts',
    'tsx',
    'js',
    'jsx',
  ];
}
```

it allows the app to load mock components with the extension `.owl.ts*`.
Besides allowing mock components/data for testing only, it guarantees that no test code ends up by mistake in the production app.

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

The example app renders the **App Button** when launched via `yarn start` and **Owl Button** when launched with `owl:test:*`

### Checklist: 

- [ ] Add support for communication between mocks and test 
- [ ] Add support for Android build
- [ ] Update documentation
- [ ] Better example

### Screenshots (for visual changes):

![Simulator Screen Shot - iPhone 13 Pro - 2022-09-06 at 09 10 19](https://user-images.githubusercontent.com/6877714/188571694-38808028-7377-4c1c-9c34-cddb476ecd9b.png)

