### PR TITLE
Use fully-qualified hero URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![React Native Owl — Formidable, We build the modern web](./website/static/images/RNO-Hero.png)](https://formidable.com/open-source/)
+[![React Native Owl — Formidable, We build the modern web](https://raw.githubusercontent.com/FormidableLabs/react-native-owl/main/website/static/images/RNO-Hero.png)](https://formidable.com/open-source/)
 
 `react-native-owl` — Visual regression testing for React Native
 


### PR DESCRIPTION
This PR updates the hero image url to use the fully-qualified `raw.githubusercontent` URL so that on the NPM details page the image will show (without us having to ship the hero image).