### PR TITLE
GA/GTM IDs in docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -36,6 +36,15 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        ...(process.env.VERCEL_ENV === 'production' && {
+          gtag: {
+            trackingID: process.env.GTAG_TRACKING_ID,
+            anonymizeIP: true,
+          },
+          googleTagManager: {
+            containerId: process.env.GTM_CONTAINER_ID,
+          },
+        }),
       }),
     ],
   ],


### PR DESCRIPTION
This PR adds GA/GTM values in docusaurus config. Env variables have been updated in Vercel accordingly.