### PR TITLE
feat: Add testPathPattern option for running specific tests

### DIFF
--- a/.changeset/rude-mayflies-sit.md
+++ b/.changeset/rude-mayflies-sit.md
@@ -1,0 +1,5 @@
+---
+'react-native-owl': minor
+---
+
+implements a new `testPathPattern` option for the CLI, allowing users to run tests for specific path patterns.

--- a/.changeset/weak-files-push.md
+++ b/.changeset/weak-files-push.md
@@ -1,0 +1,5 @@
+---
+'react-native-owl': minor
+---
+
+implements a new `testPathPattern` option for the CLI, allowing users to run tests for specific path patterns.Key changes:- Added a new CLI option

--- a/.changeset/weak-files-push.md
+++ b/.changeset/weak-files-push.md
@@ -1,5 +1,0 @@
----
-'react-native-owl': minor
----
-
-implements a new `testPathPattern` option for the CLI, allowing users to run tests for specific path patterns.Key changes:- Added a new CLI option

--- a/lib/cli/index.ts
+++ b/lib/cli/index.ts
@@ -28,6 +28,13 @@ const updateOption: Options = {
   default: false,
 };
 
+const testPathPatternOption: Options = {
+  alias: 't',
+  describe: 'Run Test for a matching path pattern',
+  type: 'string',
+  default: '',
+};
+
 const builderOptionsRun = {
   config: configOption,
   platform: plaformOption,
@@ -37,6 +44,7 @@ const builderOptionsTest = {
   config: configOption,
   platform: plaformOption,
   update: updateOption,
+  testPathPattern: testPathPatternOption,
 };
 
 argv

--- a/lib/cli/run.test.ts
+++ b/lib/cli/run.test.ts
@@ -302,5 +302,34 @@ describe('run.ts', () => {
         await expect(mockGenerateReport).not.toHaveBeenCalled();
       }
     });
+
+    it('runs with a specific testPathPattern', async () => {
+      jest.spyOn(configHelpers, 'getConfig').mockResolvedValueOnce(config);
+      const mockRunIOS = jest.spyOn(run, 'runIOS').mockResolvedValueOnce();
+
+      const testPathPattern = '*';
+      await run.runHandler({ ...args, testPathPattern });
+
+      await expect(mockRunIOS).toHaveBeenCalled();
+      await expect(commandSyncMock).toHaveBeenCalledTimes(1);
+      await expect(commandSyncMock).toHaveBeenCalledWith(
+        `${expectedJestCommand} --globals='{\"OWL_CLI_ARGS\":{\"platform\":\"ios\",\"config\":\"./owl.config.json\",\"update\":false,\"testPathPattern\":\"${testPathPattern}\"}}' --testPathPattern="${testPathPattern}"`,
+        expect.anything()
+      );
+    });
+
+    it('runs without a testPathPattern', async () => {
+      jest.spyOn(configHelpers, 'getConfig').mockResolvedValueOnce(config);
+      const mockRunIOS = jest.spyOn(run, 'runIOS').mockResolvedValueOnce();
+
+      await run.runHandler(args);
+
+      await expect(mockRunIOS).toHaveBeenCalled();
+      await expect(commandSyncMock).toHaveBeenCalledTimes(1);
+      await expect(commandSyncMock).toHaveBeenCalledWith(
+        `${expectedJestCommand} --globals='{\"OWL_CLI_ARGS\":{\"platform\":\"ios\",\"config\":\"./owl.config.json\",\"update\":false}}'`,
+        expect.anything()
+      );
+    });
   });
 });

--- a/lib/cli/run.ts
+++ b/lib/cli/run.ts
@@ -123,8 +123,8 @@ export const runHandler = async (args: CliRunOptions) => {
     `--globals='${JSON.stringify({ OWL_CLI_ARGS: args })}'`,
   ];
 
-  if(args.testPathPattern){
-    jestCommandArgs.push('--testPathPattern=\"' + args.testPathPattern  + '\"');
+  if (args.testPathPattern) {
+    jestCommandArgs.push('--testPathPattern="' + args.testPathPattern + '"');
   }
 
   if (config.report) {

--- a/lib/cli/run.ts
+++ b/lib/cli/run.ts
@@ -123,6 +123,10 @@ export const runHandler = async (args: CliRunOptions) => {
     `--globals='${JSON.stringify({ OWL_CLI_ARGS: args })}'`,
   ];
 
+  if(args.testPathPattern){
+    jestCommandArgs.push('--testPathPattern=\"' + args.testPathPattern  + '\"');
+  }
+
   if (config.report) {
     const reportDirPath = path.join(cwd, '.owl', 'report');
     const outputFile = path.join(reportDirPath, 'jest-report.json');

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,6 +11,7 @@ export interface CliRunOptions extends Arguments {
   platform: Platform;
   config: string;
   update: boolean;
+  testPathPattern: string;
 }
 
 export type ConfigEnv = {


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/react-native-owl/blob/main/.github/CODE_OF_CONDUCT.md

-->

### Description

Add testPathPattern option for running specific tests

This PR introduces a new CLI option testPathPattern to allow running specific tests based on a matching path pattern. This feature enhances the flexibility of test execution, enabling developers to focus on particular test files or directories.

Key changes:
 - Added a new testPathPattern option to the CLI
 - Updated the runHandler function to include the new option in Jest command arguments
 - Added new test cases to verify the functionality with and without the testPathPattern
 - Updated type definitions to include the new option

#### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Adding or updating CI (Actions)
- [x] This change requires a documentation update

### How Has This Been Tested?

New test cases have been added to run.test.ts to verify the functionality:

-  A test case to ensure the CLI runs with a specific testPathPattern
- A test case to confirm the CLI runs correctly without a testPathPattern
These tests mock the necessary dependencies and verify that the Jest command is constructed correctly with and without the new option.

### Checklist: 

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My code follows the style guidelines of this project (I have run `yarn prettier:apply`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

### Screenshots (for visual changes):

N/A (No visual changes in this PR)
