### PR TITLE
Feat: pass along Jest testNamePattern argument if provided

### DIFF
--- a/.changeset/great-mayflies-explain.md
+++ b/.changeset/great-mayflies-explain.md
@@ -1,0 +1,5 @@
+---
+'react-native-owl': minor
+---
+
+Ability to pass along Jest testNamePattern when the argument is provided

--- a/docs/cli/testing-the-app.mdx
+++ b/docs/cli/testing-the-app.mdx
@@ -11,11 +11,13 @@ Use the `test` command to run the app on the simulator, either comparing screens
 
 #### Options
 
-| Name               | Required | Default           | Options/Types   | Description                                     |
-| ------------------ | -------- | ----------------- | --------------- | ----------------------------------------------- |
-| `--config`, `-c`   | false    | ./owl.config.json | String          | Path to the configuration file                  |
-| `--platform`, `-p` | true     | -                 | `ios`,`android` | The platform the app should be built on         |
-| `--update`, `-u`   | true     | false             | Boolean         | A flag about rewriting existing baseline images |
+| Name                      | Required | Default           | Options/Types   | Description                                       |
+| ------------------------- | -------- | ----------------- | --------------- | ------------------------------------------------- |
+| `--config`, `-c`          | false    | ./owl.config.json | String          | Path to the configuration file                    |
+| `--platform`, `-p`        | true     | -                 | `ios`,`android` | The platform the app should be built on           |
+| `--update`, `-u`          | true     | false             | Boolean         | A flag about rewriting existing baseline images   |
+| `--testNamePattern`, `-t` | false    | false             | String          | Run only tests with a name that matches the regex |
+| `--testPathPattern`, `-p` | false    | false             | String          | A regexp string matched against all tests path    |
 
 When comparing images, any difference in the current vs baseline will fail the test.
 

--- a/lib/cli/index.ts
+++ b/lib/cli/index.ts
@@ -28,6 +28,12 @@ const updateOption: Options = {
   default: false,
 };
 
+const testNamePattern: Options = {
+  alias: 't',
+  describe: 'Run only tests with a name that matches the regex',
+  type: 'string',
+};
+
 const builderOptionsRun = {
   config: configOption,
   platform: plaformOption,
@@ -37,6 +43,7 @@ const builderOptionsTest = {
   config: configOption,
   platform: plaformOption,
   update: updateOption,
+  testNamePattern: testNamePattern,
 };
 
 argv

--- a/lib/cli/run.test.ts
+++ b/lib/cli/run.test.ts
@@ -302,5 +302,27 @@ describe('run.ts', () => {
         await expect(mockGenerateReport).not.toHaveBeenCalled();
       }
     });
+
+    it('runs Jest with the correct testNamePattern when the argument is provided', async () => {
+      jest.spyOn(configHelpers, 'getConfig').mockResolvedValueOnce(config);
+      const mockRunIOS = jest.spyOn(run, 'runIOS').mockResolvedValueOnce();
+
+      await run.runHandler({ ...args, testNamePattern: 'MyTest' });
+
+      await expect(mockRunIOS).toHaveBeenCalled();
+      await expect(commandSyncMock).toHaveBeenCalledTimes(1);
+      await expect(commandSyncMock).toHaveBeenCalledWith(
+        `${expectedJestCommand} --globals='{\"OWL_CLI_ARGS\":{\"platform\":\"ios\",\"config\":\"./owl.config.json\",\"update\":false,\"testNamePattern\":\"MyTest\"}}' -t MyTest`,
+        {
+          env: {
+            OWL_DEBUG: 'false',
+            OWL_IOS_SIMULATOR: 'iPhone Simulator',
+            OWL_PLATFORM: 'ios',
+            OWL_UPDATE_BASELINE: 'false',
+          },
+          stdio: 'inherit',
+        }
+      );
+    });
   });
 });

--- a/lib/cli/run.ts
+++ b/lib/cli/run.ts
@@ -132,6 +132,10 @@ export const runHandler = async (args: CliRunOptions) => {
     jestCommandArgs.push(`--json --outputFile=${outputFile}`);
   }
 
+  if (args.testNamePattern) {
+    jestCommandArgs.push(`-t`, `${args.testNamePattern}`);
+  }
+
   const jestCommand = jestCommandArgs.join(' ');
 
   logger.print(

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,6 +11,7 @@ export interface CliRunOptions extends Arguments {
   platform: Platform;
   config: string;
   update: boolean;
+  testNamePattern: string;
 }
 
 export type ConfigEnv = {


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/react-native-owl/blob/main/.github/CODE_OF_CONDUCT.md

-->

### Description

Adds ability to pass along Jest's testNamePattern argument if provided when running the tests

Fixes # (issue)

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Adding or updating CI (Actions)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (I have run `yarn prettier:apply`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

### Screenshots (for visual changes):
